### PR TITLE
Fixed obvious mistake, RenderableGraph constructor now uses same factory

### DIFF
--- a/src/main/java/edu/kit/ipd/dbis/gui/grapheditor/GraphEditorUI.java
+++ b/src/main/java/edu/kit/ipd/dbis/gui/grapheditor/GraphEditorUI.java
@@ -177,10 +177,10 @@ public class GraphEditorUI extends JPanel {
 		propertyGraph = graph;
 		if (currentColoringType == ColoringType.VERTEX) {
 			currentVertexColoring = GraphEditorController.getVertexColoring(graph);
-			this.graph = new RenderableGraph(graph, currentVertexColoring);
+			this.graph = new RenderableGraph(graph, currentVertexColoring, this.factory);
 		} else {
 			currentTotalColoring = GraphEditorController.getTotalColoring(graph);
-			this.graph = new RenderableGraph(graph, currentTotalColoring);
+			this.graph = new RenderableGraph(graph, currentTotalColoring, this.factory);
 		}
 		history.clear();
 		arrangeGraph();
@@ -194,7 +194,7 @@ public class GraphEditorUI extends JPanel {
 	 */
 	public void displayGraph(PropertyGraph<Integer, Integer> graph, VertexColoringAlgorithm.Coloring<Integer> coloring) {
 		propertyGraph = graph;
-		this.graph = new RenderableGraph(graph, coloring);
+		this.graph = new RenderableGraph(graph, coloring, this.factory);
 		history.clear();
 		arrangeGraph();
 		graphEditor.repaint();
@@ -207,7 +207,7 @@ public class GraphEditorUI extends JPanel {
 	 */
 	public void displayGraph(PropertyGraph<Integer, Integer> graph, TotalColoringAlgorithm.TotalColoring<Integer, Integer> coloring) {
 		propertyGraph = graph;
-		this.graph = new RenderableGraph(graph, coloring);
+		this.graph = new RenderableGraph(graph, coloring, this.factory);
 		history.clear();
 		arrangeGraph();
 		graphEditor.repaint();

--- a/src/main/java/edu/kit/ipd/dbis/gui/grapheditor/RenderableGraph.java
+++ b/src/main/java/edu/kit/ipd/dbis/gui/grapheditor/RenderableGraph.java
@@ -65,12 +65,11 @@ public class RenderableGraph {
 	 *
 	 * @param propertyGraph the input graph
 	 */
-	public RenderableGraph(PropertyGraph<Integer, Integer> propertyGraph) {
+	public RenderableGraph(PropertyGraph<Integer, Integer> propertyGraph, VertexFactory factory) {
 		this.edges = new HashSet<>();
 		this.vertices = new HashSet<>();
 		this.subgraphs = new HashSet<>();
 		this.id = propertyGraph.getId();
-		VertexFactory factory = new VertexFactory();
 		Map<Object, Vertex> objectVertexMap = new HashMap<>();
 		Set<Object> addedEdges = new HashSet<>();
 
@@ -155,13 +154,11 @@ public class RenderableGraph {
 	 * @param <V> the type representing vertices
 	 * @param <E> the type representing edges
 	 */
-	public <V, E> RenderableGraph(PropertyGraph<V, E> propertyGraph, VertexColoringAlgorithm.Coloring<V> coloring) {
+	public <V, E> RenderableGraph(PropertyGraph<V, E> propertyGraph, VertexColoringAlgorithm.Coloring<V> coloring, VertexFactory factory) {
 		this.edges = new HashSet<>();
 		this.vertices = new HashSet<>();
 		this.subgraphs = new HashSet<>();
 		this.id = propertyGraph.getId();
-
-		VertexFactory factory = new VertexFactory();
 
 		Color[] colorArray = GraphLook.spreadColors(coloring.getNumberColors());
 		Map<Integer, Color> colorsToColorObjectMap = new HashMap<>();
@@ -229,13 +226,11 @@ public class RenderableGraph {
 	 * @param <V> the type representing vertices
 	 * @param <E> the type representing edges
 	 */
-	public <V, E> RenderableGraph(PropertyGraph<V, E> propertyGraph, TotalColoringAlgorithm.TotalColoring coloring) {
+	public <V, E> RenderableGraph(PropertyGraph<V, E> propertyGraph, TotalColoringAlgorithm.TotalColoring coloring, VertexFactory factory) {
 		this.edges = new HashSet<>();
 		this.vertices = new HashSet<>();
 		this.subgraphs = new HashSet<>();
 		this.id = propertyGraph.getId();
-
-		VertexFactory factory = new VertexFactory();
 
 		Color[] colorArray = GraphLook.spreadColors(coloring.getNumberColors());
 		Map<Integer, Color> vertexColorsToColorMap = new HashMap<>();

--- a/src/test/java/edu/kit/ipd/dbis/gui/grapheditor/RenderableGraphTest.java
+++ b/src/test/java/edu/kit/ipd/dbis/gui/grapheditor/RenderableGraphTest.java
@@ -24,7 +24,7 @@ public class RenderableGraphTest {
 		graph.addEdge(1, 3);
 		graph.addEdge(2, 3);
 		graph.addEdge(2, 4);
-		RenderableGraph renderableGraph = new RenderableGraph(graph);
+		RenderableGraph renderableGraph = new RenderableGraph(graph, new VertexFactory());
 		assertEquals(graph.vertexSet().size(), renderableGraph.getVertices().size());
 		assertEquals(graph.edgeSet().size(), renderableGraph.getEdges().size());
 	}
@@ -44,7 +44,7 @@ public class RenderableGraphTest {
 		MinimalTotalColoring alg = new MinimalTotalColoring(graph);
 
 		TotalColoringAlgorithm.TotalColoring coloring = alg.getColoring();
-		RenderableGraph renderableGraph = new RenderableGraph(graph, coloring);
+		RenderableGraph renderableGraph = new RenderableGraph(graph, coloring, new VertexFactory());
 
 		assertEquals(graph.vertexSet().size(), renderableGraph.getVertices().size());
 		assertEquals(graph.edgeSet().size(), renderableGraph.getEdges().size());
@@ -61,7 +61,7 @@ public class RenderableGraphTest {
 		graph.addEdge(0, 2);
 		graph.addEdge(1, 2);
 		graph.addEdge(1, 3);
-		RenderableGraph renderableGraph = new RenderableGraph(graph);
+		RenderableGraph renderableGraph = new RenderableGraph(graph, new VertexFactory());
 		assertEquals(true, graph.equals(renderableGraph.asPropertyGraph()));
 	}
 
@@ -76,10 +76,10 @@ public class RenderableGraphTest {
 		graph.addEdge(0, 2);
 		graph.addEdge(1, 2);
 		graph.addEdge(1, 3);
-		RenderableGraph renderableGraph = new RenderableGraph(graph);
+		RenderableGraph renderableGraph = new RenderableGraph(graph, new VertexFactory());
 		PropertyGraph<Integer, Integer> graph2 = renderableGraph.asPropertyGraph();
 		assertEquals(true, graph.equals(graph2));
-		renderableGraph = new RenderableGraph(graph2);
+		renderableGraph = new RenderableGraph(graph2, new VertexFactory());
 		graph2 = renderableGraph.asPropertyGraph();
 		assertEquals(true, graph.equals(graph2));
 	}
@@ -98,13 +98,13 @@ public class RenderableGraphTest {
 		VertexColoringAlgorithm.Coloring<Integer> coloring =
 				((List<VertexColoringAlgorithm.Coloring<Integer>>) graph.getProperty(VertexColoring.class).getValue()).get(0);
 
-		RenderableGraph renderableGraph = new RenderableGraph(graph, coloring);
+		RenderableGraph renderableGraph = new RenderableGraph(graph, coloring, new VertexFactory());
 		PropertyGraph<Integer, Integer> graph2 = renderableGraph.asPropertyGraph();
 		assertEquals(true, graph.equals(graph2));
-		renderableGraph = new RenderableGraph(graph2, coloring);
+		renderableGraph = new RenderableGraph(graph2, coloring, new VertexFactory());
 		graph2 = renderableGraph.asPropertyGraph();
 		assertEquals(true, graph.equals(graph2));
-		renderableGraph = new RenderableGraph(graph2, coloring);
+		renderableGraph = new RenderableGraph(graph2, coloring, new VertexFactory());
 		graph2 = renderableGraph.asPropertyGraph();
 		assertEquals(true, graph.equals(graph2));
 	}


### PR DESCRIPTION
That way, the vertices' ids stay consistent, and do not suddenly start
at 0 again, resulting in NullPointerExceptions in said constructor.